### PR TITLE
Error ortográfico en el Readme en español

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -32,7 +32,7 @@ Vamos a construir una versión minimalista del [Banco de datos de Star Wars](htt
 
 ***Importante 2***: no se preocupe si los datos que obtiene de la SWAPI no coinciden con los datos que ve en starwars.com.
 
-Usa toda la información provista por el SWAPI (verifique los documentos y / o las respuestas de json).
+Usa toda la información provista por la SWAPI (verifique los documentos y / o las respuestas de json).
 
 ## Leer más tarde o la funcionalidad de favoritos
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _The force is strong with this exercise..._
 
 We are going to be building a minimalist version of the [Star Wars Databank](https://www.starwars.com/databank) with a React Later or Favorites list functionality.
 
-### Here is the demo!
+### Here is the demo !
 
 <p align="center">
    <img src="https://projects.breatheco.de/json?slug=startwars-blog-reading-list&preview" />


### PR DESCRIPTION
la forma en que se escribe <EL SWAPI> o <LA SWAPI>  no estaba unificado en las lineas 31 33 y 35 del Readme en español,  la linea 31 decia "EL" en la 33 "LA" y la 35 "EL" otra vez.